### PR TITLE
Asset type update

### DIFF
--- a/Aster.Net/Aster.Net.csproj
+++ b/Aster.Net/Aster.Net.csproj
@@ -53,13 +53,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Secp256k1.Net" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Aster.Net/Aster.Net.csproj
+++ b/Aster.Net/Aster.Net.csproj
@@ -53,11 +53,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Secp256k1.Net" Version="2.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Aster.Net/Clients/FuturesApi/AsterRestClientFuturesApiShared.cs
+++ b/Aster.Net/Clients/FuturesApi/AsterRestClientFuturesApiShared.cs
@@ -130,6 +130,7 @@ namespace Aster.Net.Clients.FuturesApi
         #endregion
 
         #region Futures Symbol client
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } 
             = new GetFuturesSymbolsOptions(_exchangeName, false);

--- a/Aster.Net/Clients/FuturesApi/AsterRestClientFuturesApiShared.cs
+++ b/Aster.Net/Clients/FuturesApi/AsterRestClientFuturesApiShared.cs
@@ -130,7 +130,7 @@ namespace Aster.Net.Clients.FuturesApi
         #endregion
 
         #region Futures Symbol client
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
 
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } 
             = new GetFuturesSymbolsOptions(_exchangeName, false);

--- a/Aster.Net/Clients/FuturesV3Api/AsterRestClientFuturesV3ApiShared.cs
+++ b/Aster.Net/Clients/FuturesV3Api/AsterRestClientFuturesV3ApiShared.cs
@@ -1,15 +1,17 @@
+using Aster.Net.Enums;
+using Aster.Net.Interfaces.Clients.FuturesV3Api;
+using Aster.Net.Objects.Models;
+using CryptoExchange.Net;
+using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Aster.Net.Interfaces.Clients.FuturesV3Api;
+using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using CryptoExchange.Net.Objects;
-using System.Linq;
-using Aster.Net.Enums;
-using CryptoExchange.Net;
-using CryptoExchange.Net.Objects.Errors;
-using Aster.Net.Objects.Models;
 
 namespace Aster.Net.Clients.FuturesV3Api
 {
@@ -131,7 +133,8 @@ namespace Aster.Net.Clients.FuturesV3Api
 
         #region Futures Symbol client
 
-        GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } 
+        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; }
             = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -143,25 +146,51 @@ namespace Aster.Net.Clients.FuturesV3Api
             if (!result.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
-            var data = result.Data.Symbols.Where(x => x.ContractType != null);            
-            var resultData = HttpResult.Ok(result, data.Select(s =>
-                new SharedFuturesSymbol(s.ContractType == ContractType.Perpetual ? TradingMode.PerpetualLinear : TradingMode.DeliveryLinear,
+            var data = result.Data.Symbols
+                .Where(x => x.ContractType != null)
+                .Select(x => ParseSymbol(x))
+                .ToArray();
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
+        }
+
+        private SharedFuturesSymbol ParseSymbol(AsterSymbol s)
+        {
+            var symbol = new SharedFuturesSymbol(s.ContractType == ContractType.Perpetual ? TradingMode.PerpetualLinear : TradingMode.DeliveryLinear,
                 s.BaseAsset,
                 s.QuoteAsset,
                 s.Name,
                 s.Status == SymbolStatus.Trading)
-                {
-                    MinTradeQuantity = s.LotSizeFilter?.MinQuantity,
-                    MaxTradeQuantity = s.LotSizeFilter?.MaxQuantity,
-                    QuantityStep = s.LotSizeFilter?.StepSize,
-                    PriceStep = s.PriceFilter?.TickSize,
-                    MinNotionalValue = s.MinNotionalFilter?.MinNotional,
-                    ContractSize = 1,
-                    DeliveryTime = s.DeliveryDate.Year == 2100 ? null : s.DeliveryDate
-                }).ToArray());
+            {
+                MinTradeQuantity = s.LotSizeFilter?.MinQuantity,
+                MaxTradeQuantity = s.LotSizeFilter?.MaxQuantity,
+                QuantityStep = s.LotSizeFilter?.StepSize,
+                PriceStep = s.PriceFilter?.TickSize,
+                MinNotionalValue = s.MinNotionalFilter?.MinNotional,
+                ContractSize = 1,
+                DeliveryTime = s.DeliveryDate.Year == 2100 ? null : s.DeliveryDate,
+                DisplayName = s.Name,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = SharedAssetSubType.StableCoin
+            };
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.Data!);
-            return resultData;
+            if (s.UnderlyingSubType.Contains("STOCK"))
+            {
+                symbol.BaseAssetType = SharedAssetType.Rwa;
+                symbol.BaseAssetSubType = SharedAssetSubType.Stock;
+            }
+            else if (s.UnderlyingSubType.Contains("Commodities"))
+            {
+                symbol.BaseAssetType = SharedAssetType.Rwa;
+                symbol.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else
+            {
+                symbol.BaseAssetType = SharedAssetType.Crypto;
+            }
+
+            return symbol;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/Aster.Net/Clients/FuturesV3Api/AsterRestClientFuturesV3ApiShared.cs
+++ b/Aster.Net/Clients/FuturesV3Api/AsterRestClientFuturesV3ApiShared.cs
@@ -133,7 +133,7 @@ namespace Aster.Net.Clients.FuturesV3Api
 
         #region Futures Symbol client
 
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; }
             = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/Aster.Net/Clients/FuturesV3Api/AsterRestClientFuturesV3ApiShared.cs
+++ b/Aster.Net/Clients/FuturesV3Api/AsterRestClientFuturesV3ApiShared.cs
@@ -178,7 +178,7 @@ namespace Aster.Net.Clients.FuturesV3Api
             if (s.UnderlyingSubType.Contains("STOCK"))
             {
                 symbol.BaseAssetType = SharedAssetType.TradFi;
-                symbol.BaseAssetSubType = SharedAssetSubType.Stock;
+                symbol.BaseAssetSubType = SharedAssetSubType.Equity;
             }
             else if (s.UnderlyingSubType.Contains("Commodities"))
             {

--- a/Aster.Net/Clients/FuturesV3Api/AsterRestClientFuturesV3ApiShared.cs
+++ b/Aster.Net/Clients/FuturesV3Api/AsterRestClientFuturesV3ApiShared.cs
@@ -133,7 +133,7 @@ namespace Aster.Net.Clients.FuturesV3Api
 
         #region Futures Symbol client
 
-        SharedSymbolCatalog? IFuturesSymbolRestClient.SymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; }
             = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -177,12 +177,12 @@ namespace Aster.Net.Clients.FuturesV3Api
 
             if (s.UnderlyingSubType.Contains("STOCK"))
             {
-                symbol.BaseAssetType = SharedAssetType.Rwa;
+                symbol.BaseAssetType = SharedAssetType.TradFi;
                 symbol.BaseAssetSubType = SharedAssetSubType.Stock;
             }
             else if (s.UnderlyingSubType.Contains("Commodities"))
             {
-                symbol.BaseAssetType = SharedAssetType.Rwa;
+                symbol.BaseAssetType = SharedAssetType.TradFi;
                 symbol.BaseAssetSubType = SharedAssetSubType.Commodity;
             }
             else

--- a/Aster.Net/Clients/SpotApi/AsterRestClientSpotApiShared.cs
+++ b/Aster.Net/Clients/SpotApi/AsterRestClientSpotApiShared.cs
@@ -81,7 +81,7 @@ namespace Aster.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/Aster.Net/Clients/SpotApi/AsterRestClientSpotApiShared.cs
+++ b/Aster.Net/Clients/SpotApi/AsterRestClientSpotApiShared.cs
@@ -81,6 +81,7 @@ namespace Aster.Net.Clients.SpotApi
         #endregion
 
         #region Spot Symbol client
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/Aster.Net/Clients/SpotV3Api/AsterRestClientSpotV3ApiShared.cs
+++ b/Aster.Net/Clients/SpotV3Api/AsterRestClientSpotV3ApiShared.cs
@@ -111,7 +111,11 @@ namespace Aster.Net.Clients.SpotV3Api
                 MaxTradeQuantity = s.LotSizeFilter?.MaxQuantity,
                 MinNotionalValue = s.MinNotionalFilter?.MinNotional,
                 QuantityStep = s.LotSizeFilter?.StepSize,
-                PriceStep = s.PriceFilter?.TickSize
+                PriceStep = s.PriceFilter?.TickSize,
+                DisplayName = s.Name,
+                QuoteAssetType = SharedAssetType.Crypto,
+                QuoteAssetSubType = SharedAssetSubType.StableCoin,
+                BaseAssetType = SharedAssetType.Crypto
             };
 
             return result;

--- a/Aster.Net/Clients/SpotV3Api/AsterRestClientSpotV3ApiShared.cs
+++ b/Aster.Net/Clients/SpotV3Api/AsterRestClientSpotV3ApiShared.cs
@@ -82,7 +82,7 @@ namespace Aster.Net.Clients.SpotV3Api
         #endregion
 
         #region Spot Symbol client
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/Aster.Net/Clients/SpotV3Api/AsterRestClientSpotV3ApiShared.cs
+++ b/Aster.Net/Clients/SpotV3Api/AsterRestClientSpotV3ApiShared.cs
@@ -82,6 +82,7 @@ namespace Aster.Net.Clients.SpotV3Api
         #endregion
 
         #region Spot Symbol client
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -94,17 +95,26 @@ namespace Aster.Net.Clients.SpotV3Api
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var resultData = HttpResult.Ok(result, result.Data.Symbols.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Name, s.Status == SymbolStatus.Trading)
+            var data = result.Data.Symbols
+                .Select(x => ParseSymbol(x))
+                .ToArray();
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
+        }
+
+        private SharedSpotSymbol ParseSymbol(AsterSpotSymbol s)
+        {
+            var result = new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Name, s.Status == SymbolStatus.Trading)
             {
                 MinTradeQuantity = s.LotSizeFilter?.MinQuantity,
                 MaxTradeQuantity = s.LotSizeFilter?.MaxQuantity,
                 MinNotionalValue = s.MinNotionalFilter?.MinNotional,
                 QuantityStep = s.LotSizeFilter?.StepSize,
                 PriceStep = s.PriceFilter?.TickSize
-            }).ToArray());
+            };
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.Data!);
-            return resultData;
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models|
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models|
Added DebuggerDisplay attributes to Shared models|